### PR TITLE
Impliment Wait from embedded-hal-async

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,9 @@ features = [ "unproven" ]
 package = "embedded-hal"
 version = "1.0.0"
 
+[dependencies.eh1_0_async]
+package = "embedded-hal-async"
+version = "1.0.0"
 
 [package.metadata.docs.rs]
 # To build locally:

--- a/src/forward.rs
+++ b/src/forward.rs
@@ -98,6 +98,38 @@ mod digital {
         }
     }
 
+    impl<T, E> eh1_0_async::digital::Wait for Forward<T, ForwardInputPin>
+    where
+        T: eh0_2::digital::v2::InputPin<Error = E> + eh1_0_async::digital::Wait<Error = E>,
+        E: core::fmt::Debug,
+    {
+        async fn wait_for_high(&mut self) -> Result<(), Self::Error> {
+            self.inner.wait_for_high().await.map_err(ForwardError)
+        }
+
+        async fn wait_for_low(&mut self) -> Result<(), Self::Error> {
+            self.inner.wait_for_low().await.map_err(ForwardError)
+        }
+
+        async fn wait_for_rising_edge(&mut self) -> Result<(), Self::Error> {
+            self.inner
+                .wait_for_rising_edge()
+                .await
+                .map_err(ForwardError)
+        }
+
+        async fn wait_for_falling_edge(&mut self) -> Result<(), Self::Error> {
+            self.inner
+                .wait_for_falling_edge()
+                .await
+                .map_err(ForwardError)
+        }
+
+        async fn wait_for_any_edge(&mut self) -> Result<(), Self::Error> {
+            self.inner.wait_for_any_edge().await.map_err(ForwardError)
+        }
+    }
+
     impl<T, E> eh1_0::digital::ErrorType for Forward<T, ForwardOutputPin>
     where
         T: eh0_2::digital::v2::OutputPin<Error = E>,
@@ -119,6 +151,38 @@ mod digital {
         /// Set the output as low
         fn set_low(&mut self) -> Result<(), Self::Error> {
             self.inner.set_low().map_err(ForwardError)
+        }
+    }
+
+    impl<T, E> eh1_0_async::digital::Wait for Forward<T, ForwardOutputPin>
+    where
+        T: eh0_2::digital::v2::OutputPin<Error = E> + eh1_0_async::digital::Wait<Error = E>,
+        E: core::fmt::Debug,
+    {
+        async fn wait_for_high(&mut self) -> Result<(), Self::Error> {
+            self.inner.wait_for_high().await.map_err(ForwardError)
+        }
+
+        async fn wait_for_low(&mut self) -> Result<(), Self::Error> {
+            self.inner.wait_for_low().await.map_err(ForwardError)
+        }
+
+        async fn wait_for_rising_edge(&mut self) -> Result<(), Self::Error> {
+            self.inner
+                .wait_for_rising_edge()
+                .await
+                .map_err(ForwardError)
+        }
+
+        async fn wait_for_falling_edge(&mut self) -> Result<(), Self::Error> {
+            self.inner
+                .wait_for_falling_edge()
+                .await
+                .map_err(ForwardError)
+        }
+
+        async fn wait_for_any_edge(&mut self) -> Result<(), Self::Error> {
+            self.inner.wait_for_any_edge().await.map_err(ForwardError)
         }
     }
 
@@ -159,6 +223,40 @@ mod digital {
         /// Set the output as low
         fn set_low(&mut self) -> Result<(), Self::Error> {
             self.inner.set_low().map_err(ForwardError)
+        }
+    }
+
+    impl<T, E> eh1_0_async::digital::Wait for Forward<T, ForwardIoPin>
+    where
+        T: eh0_2::digital::v2::InputPin<Error = E>
+            + eh0_2::digital::v2::OutputPin<Error = E>
+            + eh1_0_async::digital::Wait<Error = E>,
+        E: core::fmt::Debug,
+    {
+        async fn wait_for_high(&mut self) -> Result<(), Self::Error> {
+            self.inner.wait_for_high().await.map_err(ForwardError)
+        }
+
+        async fn wait_for_low(&mut self) -> Result<(), Self::Error> {
+            self.inner.wait_for_low().await.map_err(ForwardError)
+        }
+
+        async fn wait_for_rising_edge(&mut self) -> Result<(), Self::Error> {
+            self.inner
+                .wait_for_rising_edge()
+                .await
+                .map_err(ForwardError)
+        }
+
+        async fn wait_for_falling_edge(&mut self) -> Result<(), Self::Error> {
+            self.inner
+                .wait_for_falling_edge()
+                .await
+                .map_err(ForwardError)
+        }
+
+        async fn wait_for_any_edge(&mut self) -> Result<(), Self::Error> {
+            self.inner.wait_for_any_edge().await.map_err(ForwardError)
         }
     }
 }


### PR DESCRIPTION
This is useful with crates like `atsamd-hal`, that use a lot of old/new embedded-hal traits interchangeably. 